### PR TITLE
Send an integer instead of a string

### DIFF
--- a/modules/custom.php
+++ b/modules/custom.php
@@ -307,7 +307,7 @@ class custom extends module_base
 			default:
 				if (!isset($custom_code))
 				{
-					$custom_code = generate_text_for_edit($portal_config['board3_custom_' . $module_id . '_code'], $this->config['board3_custom_' . $module_id . '_uid'], '');
+					$custom_code = generate_text_for_edit($portal_config['board3_custom_' . $module_id . '_code'], $this->config['board3_custom_' . $module_id . '_uid'], 0);
 				}
 
 				$this->template->assign_vars(array(


### PR DESCRIPTION
The flags parameter of the generate_text_for_edit function should receive an integer instead of a string.

In my case, it was throwing a phpBB warning and I was unable to access the custom module edition page.

The page looked like this 

![error](https://user-images.githubusercontent.com/4323797/42958011-98f3e944-8b84-11e8-8109-3d8bb047f13c.png)

Here is the phpBB warning

![error](https://user-images.githubusercontent.com/4323797/42957908-3f64b174-8b84-11e8-9792-399818aebd8a.png)

Here is the generate_text_for_edit function definition 

![info](https://user-images.githubusercontent.com/4323797/42957913-422f7e84-8b84-11e8-9c95-b8e5f738d205.png)
